### PR TITLE
Fikse feil ved oppdatering av manuelle inntekter

### DIFF
--- a/src/main/kotlin/no/nav/bidrag/behandling/service/InntektService.kt
+++ b/src/main/kotlin/no/nav/bidrag/behandling/service/InntektService.kt
@@ -131,9 +131,9 @@ class InntektService(
         }
 
         behandling.inntekter.removeAll(manuelleInntekterSomSkalSlettes)
-        entityManager.flush()
 
         if (oppdatereInntekterRequest.sletteInntekter.isNotEmpty()) {
+            entityManager.flush()
             log.info {
                 "Slettet ${oppdatereInntekterRequest.sletteInntekter} inntekter fra databasen."
             }

--- a/src/test/kotlin/no/nav/bidrag/behandling/controller/InntekterControllerTest.kt
+++ b/src/test/kotlin/no/nav/bidrag/behandling/controller/InntekterControllerTest.kt
@@ -3,6 +3,7 @@ package no.nav.bidrag.behandling.controller
 import io.kotest.assertions.assertSoftly
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.shouldNotBe
+import jakarta.persistence.EntityManager
 import no.nav.bidrag.behandling.database.datamodell.Inntekt
 import no.nav.bidrag.behandling.database.datamodell.Kilde
 import no.nav.bidrag.behandling.database.repository.BehandlingRepository
@@ -33,6 +34,9 @@ class InntekterControllerTest : KontrollerTestRunner() {
 
     @Autowired
     lateinit var behandlingRepository: BehandlingRepository
+
+    @Autowired
+    lateinit var entityManager: EntityManager
 
     @BeforeEach
     fun oppsett() {
@@ -203,7 +207,7 @@ class InntekterControllerTest : KontrollerTestRunner() {
         }
 
         @Test
-        open fun `skal kun være mulig å slette inntekter med kilde manuell`() {
+        fun `skal kun være mulig å slette inntekter med kilde manuell`() {
             // given
             val behandling = testdataManager.opprettBehandling(true)
 
@@ -229,15 +233,15 @@ class InntekterControllerTest : KontrollerTestRunner() {
                 )
 
             // then
-            assertSoftly {
-                respons shouldNotBe null
-                respons.statusCode shouldBe HttpStatus.CREATED
-                respons.body shouldNotBe null
-                respons.body?.inntekter?.årsinntekter?.size shouldBe 2
-                respons.body?.inntekter?.barnetillegg?.size shouldBe 0
-                respons.body?.inntekter?.utvidetBarnetrygd?.size shouldBe 0
-                respons.body?.inntekter?.kontantstøtte?.size shouldBe 0
-                respons.body?.inntekter?.månedsinntekter?.size shouldBe 0
+            assertSoftly(respons) {
+                it shouldNotBe null
+                it.statusCode shouldBe HttpStatus.CREATED
+                it.body shouldNotBe null
+                it.body?.inntekter?.årsinntekter?.size shouldBe 2
+                it.body?.inntekter?.barnetillegg?.size shouldBe 0
+                it.body?.inntekter?.utvidetBarnetrygd?.size shouldBe 0
+                it.body?.inntekter?.kontantstøtte?.size shouldBe 0
+                it.body?.inntekter?.månedsinntekter?.size shouldBe 0
             }
         }
     }

--- a/src/test/kotlin/no/nav/bidrag/behandling/controller/KontrollerTestRunner.kt
+++ b/src/test/kotlin/no/nav/bidrag/behandling/controller/KontrollerTestRunner.kt
@@ -87,5 +87,7 @@ abstract class KontrollerTestRunner : CommonTestRunner() {
         stubUtils.stubKodeverkLønnsbeskrivelse()
         stubUtils.stubKodeverkNaeringsinntektsbeskrivelser()
         stubUtils.stubKodeverkYtelsesbeskrivelser()
+        stubUtils.stubKodeverkPensjonsbeskrivelser()
+        stubUtils.stubKodeverkSpesifisertSummertSkattegrunnlag()
     }
 }

--- a/src/test/kotlin/no/nav/bidrag/behandling/service/BehandlingServiceTest.kt
+++ b/src/test/kotlin/no/nav/bidrag/behandling/service/BehandlingServiceTest.kt
@@ -893,6 +893,7 @@ class BehandlingServiceTest : TestContainerRunner() {
             )
 
             val expectedBehandling = behandlingService.hentBehandlingById(actualBehandling.id!!)
+            entityManager.refresh(expectedBehandling)
 
             assertEquals(1, expectedBehandling.inntekter.size)
             assertNotNull(expectedBehandling.inntektsbegrunnelseIVedtakOgNotat)

--- a/src/test/kotlin/no/nav/bidrag/behandling/service/InntektServiceTest.kt
+++ b/src/test/kotlin/no/nav/bidrag/behandling/service/InntektServiceTest.kt
@@ -797,6 +797,7 @@ class InntektServiceTest : TestContainerRunner() {
 
             // så
             val oppdatertBehandling = behandlingRepository.findBehandlingById(behandling.id!!)
+            entityManager.flush()
             entityManager.refresh(oppdatertBehandling.get())
 
             assertSoftly {


### PR DESCRIPTION
Flytter EntityManager.flush-kall slik at det bare kjøres ved sletting